### PR TITLE
Prevent error during species attributes update if user doesn't have access to compendium

### DIFF
--- a/src/js/sheetworkers.js
+++ b/src/js/sheetworkers.js
@@ -411,9 +411,9 @@ const wfrpModule = ( () => {
                 let skill_index = 1;
                 let talent_index = 1;
                 
-                if (skills.Fixed) skills_fixed = skills.Fixed.split(",").map(item=>item.trim());
-                if (talents.Fixed) talents_fixed = talents.Fixed.split(",").map(item=>item.trim());
-                if (talents.Choices) talents.Choices.forEach(choice => talents_choices = [...talents_choices, ...choice]);
+                if (skills && skills.Fixed) skills_fixed = skills.Fixed.split(",").map(item=>item.trim());
+                if (talents && talents.Fixed) talents_fixed = talents.Fixed.split(",").map(item=>item.trim());
+                if (talents && talents.Choices) talents.Choices.forEach(choice => talents_choices = [...talents_choices, ...choice]);
     
                 for (let index = 1; index <= 12; index++) {
                     update[`species_skill_${index}_name`] = "";

--- a/wfrp4.html
+++ b/wfrp4.html
@@ -9076,9 +9076,9 @@
                 let skill_index = 1;
                 let talent_index = 1;
                 
-                if (skills.Fixed) skills_fixed = skills.Fixed.split(",").map(item=>item.trim());
-                if (talents.Fixed) talents_fixed = talents.Fixed.split(",").map(item=>item.trim());
-                if (talents.Choices) talents.Choices.forEach(choice => talents_choices = [...talents_choices, ...choice]);
+                if (skills && skills.Fixed) skills_fixed = skills.Fixed.split(",").map(item=>item.trim());
+                if (talents && talents.Fixed) talents_fixed = talents.Fixed.split(",").map(item=>item.trim());
+                if (talents && talents.Choices) talents.Choices.forEach(choice => talents_choices = [...talents_choices, ...choice]);
     
                 for (let index = 1; index <= 12; index++) {
                     update[`species_skill_${index}_name`] = "";


### PR DESCRIPTION
Hi Nic

This is a copy of Roll20/roll20-character-sheets#8202 .
This change should finally fix issue with Fate, Resilience, Movement and Size attributes not updated on species change in case if user doesn't have access to compendium.